### PR TITLE
Fix for e-mails with attachments

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 setup(
     name='django-uwsgi-mail',
-    version='1.0',
+    version='1.1',
     author='Jayson Reis',
     author_email='santosdosreis@gmail.com',
     description='A Django backend for e-mail delivery using uWSGI Spool to queue deliveries.',

--- a/uwsgi_mail/uwsgi.py
+++ b/uwsgi_mail/uwsgi.py
@@ -19,5 +19,5 @@ class EmailBackend(BaseEmailBackend):
 
     def _send(self, email_message):
         from uwsgi_mail.task import send_mail
-        send_mail.spool(email_message=dumps(email_message))
+        send_mail.spool(email_message=dumps(email_message, 2))
         return True


### PR DESCRIPTION
The default of pickle.dumps is the ASCII protocol. A binary attachment to an e-mail
message caused the spooler method to die with: `ValueError: insecure string pickle`.
Using protocol 2 fixes this problem.
