### PR TITLE
Allow messages bigger than the buffer-size

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 setup(
     name='django-uwsgi-mail',
-    version='1.1',
+    version='1.2',
     author='Jayson Reis',
     author_email='santosdosreis@gmail.com',
     description='A Django backend for e-mail delivery using uWSGI Spool to queue deliveries.',

--- a/uwsgi_mail/task.py
+++ b/uwsgi_mail/task.py
@@ -14,4 +14,4 @@ BACKEND = getattr(settings, 'UWSGI_EMAIL_BACKEND',
 @spool
 def send_mail(arguments):
     conn = get_connection(backend=BACKEND)
-    conn.send_messages([loads(arguments['email_message'])])
+    conn.send_messages([loads(arguments['body'])])

--- a/uwsgi_mail/uwsgi.py
+++ b/uwsgi_mail/uwsgi.py
@@ -19,5 +19,5 @@ class EmailBackend(BaseEmailBackend):
 
     def _send(self, email_message):
         from uwsgi_mail.task import send_mail
-        send_mail.spool(email_message=dumps(email_message, 2))
+        send_mail.spool(body=dumps(email_message, 2))
         return True


### PR DESCRIPTION
If the user adds attachments, the message can get bigger than the buffer. In that case is truncated and therefore broken.

Using the 'body' key doesn't apply the buffer-size limits.
See also http://uwsgi-docs.readthedocs.org/en/latest/Spooler.html.
